### PR TITLE
Fix setrace

### DIFF
--- a/src/act_wiz.cpp
+++ b/src/act_wiz.cpp
@@ -8003,7 +8003,7 @@ CMDF( do_setrace )
       return;
    }
 
-   if( !str_cmp( arg2, "bodyparts" ) || str_cmp( arg2, "part" ) )
+   if( !str_cmp( arg2, "bodyparts" ) || !str_cmp( arg2, "part" ) )
    {
       if( argument.empty(  ) )
       {


### PR DESCRIPTION
A missing not in the string comparison is causing arguments beyond the bodyparts if statement to not work.